### PR TITLE
fix: 当数组最后一位最大时，排序错误的问题

### DIFF
--- a/test.js
+++ b/test.js
@@ -15,7 +15,7 @@ function exchange(arr, a, b) {
 function sort(arr) {
     for (var i = 0 ; i < arr.length ; i ++) {
         var maxIndex = 0;
-        for (var j = 0 ; j < arr.length - 1 - i ; j ++) {
+        for (var j = 0 ; j < arr.length - i ; j ++) {
             if (compare(arr[maxIndex], arr[j])) {
                 maxIndex = j;
             }


### PR DESCRIPTION
因为最后一位没有进行比较，所以当数组的最后一位最大时，排序就会出问题。
所以如果传入一个排序好的数组，最大的数每一轮都会被往前推进一位，最后最大的数在数组的前面。